### PR TITLE
named action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,7 @@ on:
 jobs:
 
   build:
+    name: "build and test (go)"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The action wasn't appearing as a branch-protection status check. Apparently this is because it requires a name (which isn't created by default). Added a name 👍 